### PR TITLE
Remove 'bitmap' and 'jpeg' as allowed types from the README.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,10 @@ const async = require('async'),
                     return { mime: Jimp.MIME_BMP, extension: '.bmp' };
                 case 'jpg':
                     return { mime: Jimp.MIME_JPEG, extension: '.jpg' };
-                default:
+                case 'png':
                     return { mime: Jimp.MIME_PNG, extension: '.png' };
+                default:
+                    throw new Error(`Unrecognized extension: ${type}`);
             }
         }
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The configuration takes a set of objects with the configuration:
 ```js
 suffix: {           // If the suffix is '-1', then 'source.jpg' -> 'source-1.jpg'
     modifiers,      // Crop, Invert, Flip, Gaussian, Blur, Greyscale, Sepia, etc.
-    type            // BMP, Bitmap, JPG or JPEG. Case unnecessary and anything else is PNG.
+    type            // One of 'bmp', 'jpg', or 'png' (case insensitive)
 },
 ```
 
@@ -42,7 +42,7 @@ gulp.task('default', function () {
             rotate: 90,
             brightness: 0.5,
             contrast: 0.3,
-            type: 'bitmap'
+            type: 'bmp'
         },
         '-3': {
             posterize: 2,


### PR DESCRIPTION
Support for 'bitmap', '.bmp', 'jpeg', and '.jpeg' was removed in
<https://github.com/seamus-oconnor/gulp-jimp/commit/6e796df34fe4e7bbed89550908b79b00674b01ad>,
but the README wasn't updated to reflect the change in behavior.

I also changed the code to require that the given extension be one of
'bmp', 'jpg', or 'png', and to raise an exception if not. I understand
that this could change behavior for some users, but I think this is better
than silently converting to 'png' when a user specifies 'bitmap'.